### PR TITLE
[no-callback] handle error event and callback on save

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,18 +221,21 @@ obj.init = function(compound) {
         log(direction, migration.title);
       });
 
+      set.on('error', function(err){
+        if(err) console.log("Error: ", err);
+        callback();
+      });
+
       set.on('save', function(){
         log('migration', 'complete');
+        callback();
       });
 
       var migrationPath = migrationName
         ? join('migrations', migrationName)
         : migrationName;
      
-      set[direction](function(err){
-        if(err) console.log("Error: ", err);
-        callback();
-      }, migrationPath);
+      set[direction](migrationPath);
     }
 
 };


### PR DESCRIPTION
According to this commit tj/node-migrate@0e4f7b8b3c014ad68fbe17427c8ea73ae9e727ec, callback not passed to the migrate function anymore.
